### PR TITLE
Replace `mhuebert` repo references with new `re-view` organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Re-View is a library for building reactive user interfaces in ClojureScript.
 
 ----
 
-For full details, read the **[wiki](https://mhuebert.github.io/re-view)**.
+For full details, read the **[wiki](https://re-view.github.io/re-view)**.
 
 ----
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## Docs
 
-- The Re-View [README](https://github.com/mhuebert/re-view/blob/master/README.md)
+- The Re-View [README](https://github.com/re-view/re-view/blob/master/README.md)
 - [Getting Started](re-view/getting-started)
 - [Routing](routing)
 - [Advanced Topics](re-view/advanced-topics)
@@ -12,8 +12,8 @@
 
 Check out the [component gallery](https://re-view.matt.is), which features:
 
-- [Re-View Material](https://www.github.com/mhuebert/re-view-material), views for Google's [Material Design Components](https://github.com/material-components/material-components-web)
-- [Re-View ProseMirror](https://www.github.com/mhuebert/re-view-prosemirror), rich text editor that (de)serializes to Markdown
+- [Re-View Material](https://www.github.com/re-view/re-view-material), views for Google's [Material Design Components](https://github.com/material-components/material-components-web)
+- [Re-View ProseMirror](https://www.github.com/re-view/re-view-prosemirror), rich text editor that (de)serializes to Markdown
 
 ## Explainers
 
@@ -24,8 +24,7 @@ Check out the [component gallery](https://re-view.matt.is), which features:
 
 ## Source Code
 
-- [Re-View](https://www.github.com/mhuebert/re-view)
-- [Re-View Routing](https://www.github.com/mhuebert/re-view-routing)
-- [Re-View Hiccup](https://www.github.com/mhuebert/re-view-hiccup)
-- [Re-DB](https://www.github.com/mhuebert/re-db)
-
+- [Re-View](https://www.github.com/re-view/re-view)
+- [Re-View Routing](https://www.github.com/re-view/re-view-routing)
+- [Re-View Hiccup](https://www.github.com/re-view/re-view-hiccup)
+- [Re-DB](https://www.github.com/re-view/re-db)

--- a/docs/re-view/differences.md
+++ b/docs/re-view/differences.md
@@ -17,7 +17,7 @@ Re-View has two ways of managing state.
 
 - First, there is one **[state atom](getting-started#state-atoms)** per component. When it changes, the component is re-rendered. There is never any doubt about which component is bound to which atom. These are ordinary Clojure atoms, which do not support cursors: they are only for managing internal state, one component each. It is easy to inspect the state atom of a component at runtime.
 
-- Second, Re-View integrates with **[Re-DB](https://www.github.com/mhuebert/re-db)** for managing app-wide, global state. Similar to Reagent, reads are logged during render to determine data dependencies. But we track reads based on re-db _patterns_, so a list of entities and attributes a component depends on is visible as plain data at runtime, and we can efficiently re-render based on changes in re-db even when the number of active components is large.
+- Second, Re-View integrates with **[Re-DB](https://www.github.com/re-view/re-db)** for managing app-wide, global state. Similar to Reagent, reads are logged during render to determine data dependencies. But we track reads based on re-db _patterns_, so a list of entities and attributes a component depends on is visible as plain data at runtime, and we can efficiently re-render based on changes in re-db even when the number of active components is large.
 
 **Lifecycle Methods**
 

--- a/docs/re-view/getting-started.md
+++ b/docs/re-view/getting-started.md
@@ -147,4 +147,4 @@ If you're not sure what a Clojure atom is, check out the [atoms explainer](../ex
 
 ### Global state
 
-Re-View was written in tandem with [re-db](https://github.com/mhuebert/re-db), a tool for managing global state. When a view renders, we track which data is read from `re-db`, and update the view when that data changes. More information in the re-db [README](https://www.github.com/mhuebert/re-db).
+Re-View was written in tandem with [re-db](https://github.com/re-view/re-db), a tool for managing global state. When a view renders, we track which data is read from `re-db`, and update the view when that data changes. More information in the re-db [README](https://www.github.com/re-view/re-db).

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -1,12 +1,12 @@
 # Routing
 
-**[re-view-routing](https://github.com/mhuebert/re-view-routing)** provides an API to listen for changes to a browser's location, and parses routes into simple Clojure data structures. The current route is 'just another fact' that views can depend on.
+**[re-view-routing](https://github.com/re-view/re-view-routing)** provides an API to listen for changes to a browser's location, and parses routes into simple Clojure data structures. The current route is 'just another fact' that views can depend on.
 
 
 ## API
 
 **`re-view-routing.core/on-location-change`** calls a listener function when the browser's location changes. The listener is passed a location map consisting of the route's `:path` (string), `:segments` (vector), and `:query` (map). Options may be passed in the second parameter:
-   
+
 - `:intercept-clicks?` (boolean, `true`): For _click_ events on local links, prevent page reload & use history navigation instead.
 - `:fire-now?` (boolean, `true`): in addition to listening for changes, fire callback immediately with current parsed route. Useful for populating app state before the initial render.
 
@@ -47,24 +47,24 @@ For static routes, use `case`:
 ```clj
 ;; where `views` is a namespace of React components
 (defview root []
-  (case (d/get :route/location :segments) 
+  (case (d/get :route/location :segments)
     [] (views/home)
     ["about"] (views/about)
-    (views/not-found))) 
+    (views/not-found)))
 ```
 
 For wildcard segments, use `core.match`. Here, we bind `page-id` to a path segment, and then pass it as a prop to a view:
 
 ```clj
 (defview root []
-  (match (d/get :route/location :segments) 
+  (match (d/get :route/location :segments)
     [] (views/home)
     ["pages" page-id] (views/page {:id page-id})
     :else (views/not-found)))
-    
+
 ;; given path "/pages/x",
 ;; :segments would be ["pages" "x"],
 ;; `page-id` would bind to "x",
-;; `match` would expand to (views/page {:id "x"})    
+;; `match` would expand to (views/page {:id "x"})
 ```
 `core.match` also supports [guards](https://github.com/clojure/core.match/wiki/Basic-usage#guards) and [maps](https://github.com/clojure/core.match/wiki/Basic-usage#map-patterns), so you could also pattern-match on the `:path` string and `:query` map. (See the [wiki](https://github.com/clojure/core.match/wiki) for full details.)


### PR DESCRIPTION
(Sorry about the whitespace changes that came along for the ride.)

All repository links now point to the new re-view organization.